### PR TITLE
fix: Global Gitignore Icon Bug, chsh Prompt, and cmux DND Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,20 @@ Useful range `0.0`–`1.0`; values above `1.0` amplify but may clip. To verify w
 
 The helper exits silently while any macOS Focus / Do Not Disturb mode is engaged, so cmux stops ringing the moment you toggle on DND from Control Center.
 
+It's checked live on every notification, and **any** Focus counts — not just Do Not Disturb:
+
+| Focus active | cmux sound |
+| --- | --- |
+| Do Not Disturb | 🔇 silent |
+| Work | 🔇 silent |
+| Sleep | 🔇 silent |
+| Reduce Interruptions | 🔇 silent |
+| Nap | 🔇 silent |
+| Driving | 🔇 silent |
+| _(none)_ | 🔊 plays |
+
+If *any* Focus is on, cmux stays quiet; with no Focus engaged, it plays. Toggle a Focus on/off and the very next notification reflects it — no reload needed.
+
 **One-time setup** (the helper relies on a user-created Shortcut because macOS Tahoe retired every other shell-accessible Focus signal — `notifyutil` keys are dead, and `~/Library/DoNotDisturb/DB/Assertions.json` is now Full-Disk-Access-gated):
 
 1. Open the **Shortcuts** app.
@@ -179,6 +193,8 @@ rm -f "$tmp"
 ```
 
 You should see the focus name (e.g. `Do Not Disturb`) when one is active, empty when none is.
+
+> The **first** time the shortcut runs, macOS may show a one-time permission prompt to let it read your Focus state — approve it. It won't ask again. (If it's ever declined or unanswered, the helper just fails open and plays the sound, so cmux is never silenced by a missing grant.)
 
 The standard cmux notification banner is unaffected — only this helper's random-sound playback is suppressed. macOS itself decides whether the OS-rendered banner appears based on cmux's per-app Focus filter settings.
 

--- a/dotfiles/.gitignore_global
+++ b/dotfiles/.gitignore_global
@@ -22,8 +22,10 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
+# Custom macOS folder-icon resource. The real file is named "Icon" followed
+# by a carriage return; the bracketed CR below matches exactly that and stops
+# an editor from stripping it (a bare "Icon" would ignore every icon/Icon dir).
+Icon[]
 
 # Thumbnails
 ._*

--- a/installation/oh-my-zsh.sh
+++ b/installation/oh-my-zsh.sh
@@ -33,11 +33,22 @@ echo_green "Done."
 # change default shell
 echo_green "Setting zsh to default shell..."
 source $HOME/.zshrc
-# Use /bin/zsh on macOS to avoid /etc/shells issues with Homebrew zsh
+# Resolve the desired login shell and the one currently on record. Reading the
+# current shell needs no privileges (dscl/getent), so we can check first and
+# only `sudo chsh` when it would actually change something — otherwise a
+# re-run prompts for a sudo password just to set the shell to what it already is.
+# Use /bin/zsh on macOS to avoid /etc/shells issues with Homebrew zsh.
 if [ "$(uname -s)" = "Darwin" ]; then
-  sudo chsh -s /bin/zsh "$USER"
+  desired_shell="/bin/zsh"
+  current_shell="$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')"
 else
-  sudo chsh -s "$(command -v zsh)" "$USER"
+  desired_shell="$(command -v zsh)"
+  current_shell="$(getent passwd "$USER" 2>/dev/null | cut -d: -f7)"
+fi
+if [ "$current_shell" = "$desired_shell" ]; then
+  echo_green "Default shell is already '$desired_shell' - skipping chsh (no password needed)."
+else
+  sudo chsh -s "$desired_shell" "$USER"
 fi
 source $HOME/.zshrc
 echo_green "Done."

--- a/installation/symlink.sh
+++ b/installation/symlink.sh
@@ -121,4 +121,69 @@ fi
 echo "Rendering '$HOME/.config/cmux/settings.json' from template..."
 "$HOME/dotfiles/helpers/generate_cmux_settings.sh"
 
+# cmux Do Not Disturb / Focus support (macOS only).
+# The cmux-random-sound helper silences notification sounds while a macOS Focus
+# or Do Not Disturb mode is active, but only if a user-created Shortcut named
+# `cmux-focus-check` exists (Apple gated every other shell-readable Focus signal
+# on Tahoe, and the `shortcuts` CLI can't create shortcuts). So we can't do this
+# step for the user — we can only offer to print the one-time manual setup.
+# Idempotent: if the Shortcut already exists we say so and skip the prompt. The
+# prompt defaults to "no" after a short timeout, and is skipped entirely when
+# stdin isn't a TTY, so unattended installs never block. The `read` timeout
+# returns non-zero, which is safe here because it sits inside an `if` condition
+# (exempt from `set -e`).
+if [ "$OS" = 'darwin' ]; then
+  if command -v shortcuts >/dev/null 2>&1 && shortcuts list 2>/dev/null | grep -Fqx 'cmux-focus-check'; then
+    echo "cmux DND/Focus support: 'cmux-focus-check' Shortcut already present - notification sounds will respect Focus/DND."
+  else
+    echo "cmux can silence its notification sounds while macOS Focus / Do Not Disturb is on,"
+    echo "but that needs a one-time Shortcut you create by hand (the CLI can't make it)."
+    reply=""
+    if [ -t 0 ]; then
+      printf "Show the cmux Focus/DND setup steps now? [y/N] (defaults to no in 8s) "
+      if read -t 8 -n 1 -r reply </dev/tty; then echo; else echo; reply=""; fi
+    fi
+    case "$reply" in
+      [Yy])
+        cat <<'DNDSETUP'
+
+  cmux Focus/DND setup — do this once per machine:
+    1. Open Shortcuts.app and create a New Shortcut (the + button).
+    2. In the action list, search for "Get Current Focus" and drag it in.
+       That single action IS the whole shortcut: its output is the active
+       Focus name when one is on, or empty when none is.
+    3. Rename the shortcut to exactly:  cmux-focus-check
+    4. Close Shortcuts (it saves automatically).
+
+  Then verify it (prints the Focus name when one is on, empty otherwise):
+    t=$(mktemp); shortcuts run cmux-focus-check --output-path "$t" --output-type public.plain-text; echo "focus=[$(cat "$t")]"; rm -f "$t"
+
+  Notes:
+    - The first run may show a one-time macOS permission prompt to read your
+      Focus state - approve it (it won't ask again).
+    - Until this Shortcut exists the helper "fails open" and still plays sounds.
+    - Set CMUX_RANDOM_SOUND_IGNORE_DND=1 to bypass the check for a given cmux.
+    - Full walkthrough: README "Do Not Disturb / Focus" section.
+
+DNDSETUP
+        # Block (no timeout) so the steps stay on screen and the installer waits
+        # while you actually go create the Shortcut. `-s` keeps the keypress from
+        # echoing; `|| true` keeps `set -e` happy if stdin closes (e.g. EOF).
+        printf "Take your time — go create the Shortcut now, then press any key here to continue... "
+        read -n 1 -r -s </dev/tty || true
+        echo
+        # Auto-check whether it took, so you get immediate confirmation.
+        if command -v shortcuts >/dev/null 2>&1 && shortcuts list 2>/dev/null | grep -Fqx 'cmux-focus-check'; then
+          echo "OK: 'cmux-focus-check' Shortcut detected - cmux sounds will now respect Focus/DND."
+        else
+          echo "Note: no 'cmux-focus-check' Shortcut detected yet. No rush - create it whenever; nothing here needs re-running once it exists."
+        fi
+        ;;
+      *)
+        echo "Skipped cmux DND/Focus setup. To enable later: create a Shortcut named 'cmux-focus-check' (README \"Do Not Disturb / Focus\"), or re-run this installer."
+        ;;
+    esac
+  fi
+fi
+
 # GPG configuration is handled by installation/gpg.sh


### PR DESCRIPTION
## What & why

Three small, independent fixes bundled together, plus docs.

### `fix:` global gitignore ignoring `Icon`/`icon` directories — Fixes #30
The macOS gitignore line had lost its trailing carriage return, collapsing to a bare `Icon` pattern that ignored any directory named `Icon`/`icon` (e.g. a project's `icons/` folder). Restored the upstream editor-safe form `Icon[\r]` — a character class matching the literal CR of the real macOS custom-folder-icon resource file, which editors can't silently strip.

Verified: `icons/` and `Icon/` are no longer ignored, while the real `Icon`+CR resource file still is.

### `fix:` needless `sudo chsh` password prompt
The installer ran `sudo chsh` unconditionally, prompting for a password on every re-run even when zsh was already the login shell. Now reads the current shell first (`dscl` on macOS, `getent` on Linux — neither needs privileges) and only `chsh` when it would actually change something.

### `feat:` guide cmux DND/Focus shortcut setup during install — Fixes #29
The `cmux-random-sound` helper already silences notifications during macOS Focus/DND, but only if a user-created `cmux-focus-check` Shortcut exists — which the `shortcuts` CLI cannot create (no create/import; the Focus state is otherwise TCC-gated/`notifyutil`-dead on Tahoe). Added an idempotent, macOS-only install prompt that:

- detects an existing `cmux-focus-check` Shortcut and skips if present;
- offers the one-time setup steps, **defaulting to no after 8s** so unattended installs never block;
- **blocks on a keypress** so the steps stay on screen while you go build the Shortcut, then auto-detects whether it took.

README documents the any-Focus behavior (any Focus mode → quiet, not just DND) and the one-time macOS permission prompt.

## Testing

- gitignore: `git check-ignore` confirms `icons/`/`Icon/` no longer ignored; `Icon`+CR still ignored.
- chsh guard: dry-run on a machine already using `/bin/zsh` → skips, no prompt.
- install prompt: PTY-tested all paths — `y`→steps, Enter→skip, 8s timeout→skip (no hang), already-present→skip, non-interactive→auto-skip; `set -e` survives every branch.
- #29 end-to-end on a real Mac: `cmux-focus-check` returns `Do Not Disturb` with DND on, empty with it off → helper goes silent during any Focus.
