### PR TITLE
fix: Set push.default to Current to Avoid Clobbering master

### DIFF
--- a/dotfiles/helpers/generate_gitconfig.sh
+++ b/dotfiles/helpers/generate_gitconfig.sh
@@ -28,7 +28,11 @@ cat <<EOF > $HOME/.gitconfig
   enabled = 1
 
 [push]
-  default = upstream
+  # 'current' pushes to a remote branch with the SAME NAME as the local one,
+  # which prevents 'git push' from landing on master/main if a local branch
+  # happens to track origin/master (e.g. via autosetuprebase). Combined with
+  # autoSetupRemote, the first push of a new branch auto-creates the upstream.
+  default = current
   autoSetupRemote = true
 
 [fetch]


### PR DESCRIPTION
## What & why

Switch `push.default` from `upstream` to `current` in the generated `~/.gitconfig`.

With `push.default = upstream`, a bare `git push` from a local branch that *happens* to track `origin/master` (easy to land in with `autosetuprebase = always`) silently lands its commits on master. With `current`, a bare push always targets a same-named remote branch instead, creating it on first push thanks to the existing `autoSetupRemote = true`.

This is in the generator (`dotfiles/helpers/generate_gitconfig.sh`); the live `~/.gitconfig` is regenerated on every shell startup, so the change propagates per machine automatically.

## Verification

```
$ git config --global --get push.default
current
$ git config --global --get push.autoSetupRemote
true
```
