### PR TITLE
docs: Clarify README Intro and Supported Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # dotfiles
 
-My configuration files for some of my tools.
+My configuration files and bootstrap scripts for setting up a new macOS or Fedora machine.
 
 ## Supported Platforms
 
 - **macOS** (Apple Silicon and Intel)
-- **Fedora Linux**
+- **Fedora Linux** (and other recent `dnf`-based distributions)
 
 ## Quick Start
 


### PR DESCRIPTION
Polishes the top of the README:

- Replaces the vague tagline with a one-liner that actually describes what the repo is.
- Notes that the bootstrap scripts work on other recent `dnf`-based distributions, not just Fedora.