### PR TITLE
feat: Add safe Claude and Codex status-line config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ dotfiles/agent-config.d/
 
 - Claude JSON fragments are deep-merged into `~/.claude/settings.json`; keys
   not named by a fragment are retained. The renderer is symlinked to
-  `~/.claude/statusline-command.sh`.
+  `~/.claude/statusline-command.sh`. Its queue rollup depends on
+  [`prrq#45`](https://github.com/JonathanPorta/prrq/pull/45) and consumes
+  `prrq summary --json`; when `prrq` is missing or predates that command, the
+  optional queue segment is omitted without affecting the rest of the line.
 - Codex TOML fragments currently support the deliberately narrow
   `tui.status_line` setting. The installer updates that key inside the existing
   `[tui]` table while preserving the rest of `~/.codex/config.toml` byte for

--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ zsh -lc "$HOME/devel/$USER/dotfiles/run.sh"
 
 ## Agent status lines
 
-`init.sh` invokes `installation/agent-config.sh` when Python is already
-available; otherwise it defers the step until `run.sh` installs Python. The
-installer discovers fragments in lexical order, giving this repo a small
-Linux-style `config.d` layer even though the agent CLIs do not natively load
-config directories:
+`init.sh` and `run.sh` invoke `installation/agent-config.sh`. The wrapper selects
+an available Python 3.11+ interpreter (required for the standard-library TOML
+parser); if none is available, this optional step prints a deferral notice and
+returns successfully so the rest of the machine bootstrap continues. Re-run the
+wrapper after installing a compatible Python. The installer discovers fragments
+in lexical order, giving this repo a small Linux-style `config.d` layer even
+though the agent CLIs do not natively load config directories:
 
 ```text
 dotfiles/agent-config.d/
@@ -151,8 +153,9 @@ dotfiles/agent-config.d/
   configuration. Unsupported data is omitted instead of being scraped from
   session logs.
 
-Before either config is written, both existing configs and all fragments are
-parsed. Invalid JSON/TOML or a symlinked config aborts the run without touching
+Before either config is written, both existing configs, all fragments, and the
+renderer replacement/backup path are preflighted. Invalid JSON/TOML, a symlinked
+config, or an unsafe renderer backup conflict aborts the run without touching
 either config. The first changed version is copied to
 `*.pre-agent-config`; subsequent identical runs perform no writes.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ dotfiles/agent-config.d/
   [`prrq#45`](https://github.com/JonathanPorta/prrq/pull/45) and consumes
   `prrq summary --json`; when `prrq` is missing or predates that command, the
   optional queue segment is omitted without affecting the rest of the line.
+  Context-pressure breadcrumbs use the stable
+  `~/.local/state/claude-statusline/claude-ctx-<project-hash>.breadcrumb` reader
+  contract inside a mode-`0700` directory; each breadcrumb is mode `0600`.
 - Codex TOML fragments currently support the deliberately narrow
   `tui.status_line` setting. The installer updates that key inside the existing
   `[tui]` table while preserving the rest of `~/.codex/config.toml` byte for

--- a/README.md
+++ b/README.md
@@ -109,15 +109,58 @@ After `init.sh` completes, restart your shell and run `run.sh` (see below).
 
 | | |
 |---|---|
-| **Purpose** | Installs applications and dev tools: oh-my-zsh + plugins, vim, gpg, git-lfs, gh CLI, ruby, python, node, and more via Homebrew (macOS) or dnf (Fedora). Re-runs symlinks first. |
-| **Idempotency** | **Safe to re-run.** Package managers skip already-installed packages. Oh-my-zsh warns (but does not fail) if already present. |
-| **Destructive?** | Re-runs `symlink.sh` (same backup behavior as `init.sh`). |
+| **Purpose** | Installs applications and dev tools: oh-my-zsh + plugins, vim, gpg, git-lfs, gh CLI, ruby, python, node, and more via Homebrew (macOS) or dnf (Fedora). Re-runs symlinks first, then installs Claude and Codex status-line fragments. |
+| **Idempotency** | **Safe to re-run.** Package managers skip already-installed packages. Agent config is validated and only rewritten when the merged result changes. |
+| **Destructive?** | Re-runs `symlink.sh` (same backup behavior as `init.sh`). Agent config preserves unrelated keys and creates one `*.pre-agent-config` recovery copy before its first change. |
 
 ```bash
 zsh -lc "$HOME/devel/$USER/dotfiles/run.sh"
 ```
 
 > **Note:** `run.sh` expects to run under `zsh` with a login shell so that the full environment (Homebrew PATH, etc.) is available.
+
+---
+
+## Agent status lines
+
+`init.sh` invokes `installation/agent-config.sh` when Python is already
+available; otherwise it defers the step until `run.sh` installs Python. The
+installer discovers fragments in lexical order, giving this repo a small
+Linux-style `config.d` layer even though the agent CLIs do not natively load
+config directories:
+
+```text
+dotfiles/agent-config.d/
+├── claude/
+│   ├── 50-status-line.json
+│   └── statusline-command.sh
+└── codex/
+    └── 50-status-line.toml
+```
+
+- Claude JSON fragments are deep-merged into `~/.claude/settings.json`; keys
+  not named by a fragment are retained. The renderer is symlinked to
+  `~/.claude/statusline-command.sh`.
+- Codex TOML fragments currently support the deliberately narrow
+  `tui.status_line` setting. The installer updates that key inside the existing
+  `[tui]` table while preserving the rest of `~/.codex/config.toml` byte for
+  byte. Codex's native footer covers model, reasoning effort, context, 5-hour
+  and weekly usage, pull request number, branch changes, and project name.
+- Codex does not currently allow custom status-line commands, so Claude's cost
+  figures and `prrq` queue rollup cannot be added to the Codex footer through
+  configuration. Unsupported data is omitted instead of being scraped from
+  session logs.
+
+Before either config is written, both existing configs and all fragments are
+parsed. Invalid JSON/TOML or a symlinked config aborts the run without touching
+either config. The first changed version is copied to
+`*.pre-agent-config`; subsequent identical runs perform no writes.
+
+Run the preservation and idempotency test with:
+
+```bash
+bash tests/test-agent-config.sh
+```
 
 ---
 

--- a/dotfiles/agent-config.d/claude/50-status-line.json
+++ b/dotfiles/agent-config.d/claude/50-status-line.json
@@ -1,0 +1,6 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash \"$HOME/.claude/statusline-command.sh\""
+  }
+}

--- a/dotfiles/agent-config.d/claude/statusline-command.sh
+++ b/dotfiles/agent-config.d/claude/statusline-command.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Claude Code status line script.
+# Layout: model [fast] | e:effort | ctx% [200k warning] | 5h reset | 7d reset |
+#         PR state | estimated cost | reported cost | line delta | owner/repo |
+#         prrq queue rollup
+
+input=$(cat)
+
+# One jq pass -> fields joined by the unit separator. A non-whitespace
+# delimiter is essential: whitespace IFS collapses empty fields and shifts all
+# fields after an absent value (for example, an absent pull request).
+IFS=$'\037' read -r \
+  model model_id used_pct five_pct five_reset seven_pct seven_reset \
+  fast_mode effort exceeds pr_number pr_state repo_owner repo_name cwd \
+  cost_real lines_add lines_del total_in total_out \
+  <<<"$(printf '%s' "$input" | jq -r '[
+    .model.display_name // "unknown",
+    .model.id // "",
+    (.context_window.used_percentage // ""),
+    (.rate_limits.five_hour.used_percentage // ""),
+    (.rate_limits.five_hour.resets_at // ""),
+    (.rate_limits.seven_day.used_percentage // ""),
+    (.rate_limits.seven_day.resets_at // ""),
+    (.fast_mode // false),
+    (.effort.level // ""),
+    (.exceeds_200k_tokens // false),
+    (.pr.number // ""),
+    (.pr.review_state // ""),
+    (.workspace.repo.owner // ""),
+    (.workspace.repo.name // ""),
+    (.workspace.current_dir // .cwd // ""),
+    (.cost.total_cost_usd // ""),
+    (.cost.total_lines_added // 0),
+    (.cost.total_lines_removed // 0),
+    (.context_window.total_input_tokens // 0),
+    (.context_window.total_output_tokens // 0)
+  ] | map(tostring) | join("\u001f")')"
+
+# Leave a per-project context-pressure breadcrumb for prrq and other local
+# helpers. Readers treat a missing or stale file as unknown.
+sid=$(printf '%s' "$input" | jq -r '.session_id // ""')
+pdir=$(printf '%s' "$input" | jq -r '.workspace.project_dir // .workspace.current_dir // .cwd // ""')
+if [ -n "$used_pct" ] && [ -n "$pdir" ]; then
+  proot=$(git -C "$pdir" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$pdir")
+  pkey=$(printf '%s' "$proot" | { md5 -q 2>/dev/null || md5sum | cut -d' ' -f1; } | cut -c1-12)
+  printf '%.0f %s %s\n' "$used_pct" "${sid:-unknown}" "$(date +%s)" \
+    >"${TMPDIR:-/tmp}/claude-ctx-$pkey.breadcrumb" 2>/dev/null
+fi
+
+# Compact reset suffix: middle-dot plus days, hours, or minutes.
+fmt_reset() {
+  [ -n "$1" ] || return
+  local now delta
+  now=$(date +%s)
+  delta=$(( $1 - now ))
+  [ "$delta" -le 0 ] && return
+  if [ "$delta" -ge 86400 ]; then
+    printf '\302\267%dd' $(( delta / 86400 ))
+  elif [ "$delta" -ge 3600 ]; then
+    printf '\302\267%dh' $(( delta / 3600 ))
+  else
+    printf '\302\267%dm' $(( delta / 60 ))
+  fi
+}
+
+parts=()
+
+if [ "$fast_mode" = "true" ]; then
+  parts+=("$model ⚡")
+else
+  parts+=("$model")
+fi
+
+[ -n "$effort" ] && parts+=("e:$effort")
+
+if [ -n "$used_pct" ]; then
+  ctxseg="ctx:$(printf '%.0f' "$used_pct")%"
+  [ "$exceeds" = "true" ] && ctxseg="${ctxseg}⚠"
+  parts+=("$ctxseg")
+fi
+
+[ -n "$five_pct" ] && parts+=("5h:$(printf '%.0f' "$five_pct")%$(fmt_reset "$five_reset")")
+[ -n "$seven_pct" ] && parts+=("7d:$(printf '%.0f' "$seven_pct")%$(fmt_reset "$seven_reset")")
+
+if [ -n "$pr_number" ]; then
+  case "$pr_state" in
+    approved)          pr_glyph=" ✓" ;;
+    changes_requested) pr_glyph=" ✗" ;;
+    pending)           pr_glyph=" …" ;;
+    draft)             pr_glyph=" ◌" ;;
+    *)                 pr_glyph="" ;;
+  esac
+  parts+=("PR#${pr_number}${pr_glyph}")
+fi
+
+# The first figure is a directional token-price estimate. The second, when
+# provided by Claude Code, is its cumulative session cost.
+case "$model_id" in
+  *opus-4*|*opus-3*)                               rate_in=15; rate_out=75 ;;
+  *sonnet-4*|*sonnet-3-7*|*sonnet-3-5*|*sonnet-3*) rate_in=3; rate_out=15 ;;
+  *haiku-4*|*haiku-3-5*)                           rate_in=0.8; rate_out=4 ;;
+  *haiku-3*)                                       rate_in=0.25; rate_out=1.25 ;;
+  *)                                               rate_in=3; rate_out=15 ;;
+esac
+estimated_cost=$(awk -v ti="$total_in" -v to="$total_out" -v ri="$rate_in" -v ro="$rate_out" \
+  'BEGIN { printf "%.3f", (ti * ri / 1000000) + (to * ro / 1000000) }')
+parts+=("\$$estimated_cost")
+[ -n "$cost_real" ] && parts+=("$(awk -v c="$cost_real" 'BEGIN { printf "\316\243$%.2f", c }')")
+
+if [ "${lines_add:-0}" -gt 0 ] || [ "${lines_del:-0}" -gt 0 ]; then
+  parts+=("$(printf '\316\224+%s/-%s' "$lines_add" "$lines_del")")
+fi
+
+if [ -n "$repo_owner" ] && [ -n "$repo_name" ]; then
+  parts+=("$repo_owner/$repo_name")
+else
+  parts+=("$(basename "$cwd")")
+fi
+
+# Read the queue directly. This is deliberately lock-free and read-only: a
+# status-line render must never contend with prrq's queue writer.
+prrq_home="${PRRQ_HOME:-}"
+if [ -z "$prrq_home" ]; then
+  prrq_config="${PRRQ_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/prrq/config}"
+  [ -f "$prrq_config" ] && prrq_home=$(grep -E '^[[:space:]]*PRRQ_HOME=' "$prrq_config" 2>/dev/null | tail -1 | sed 's/^[^=]*=//')
+fi
+prrq_home="${prrq_home:-$HOME/.prrq}"
+case "$prrq_home" in
+  \~/*) prrq_home="$HOME/${prrq_home#\~/}" ;;
+esac
+
+queue="$prrq_home/queue.json"
+if [ -f "$queue" ]; then
+  rollup=$(jq -r '
+    [.items[] | select(.status != "merged" and .status != "closed")] as $open
+    | ($open | map(select(.status == "approved" or .status == "agent_approved"
+                         or .status == "human_ready" or .status == "reviewed"))) as $green
+    | ($green | map(select(.mergeable == "CONFLICTING"
+                           or .ci_state == "FAILURE" or .ci_state == "ERROR")) | length) as $gated
+    | [ (($green | length) - $gated),
+        ($open | map(select(.status == "changed")) | length),
+        ($open | map(select(.status == "changes_requested")) | length),
+        ($open | map(select(.status == "needs_review")) | length),
+        ($open | map(select(.status == "error")) | length),
+        $gated ] | @tsv' "$queue" 2>/dev/null)
+  if [ -n "$rollup" ]; then
+    IFS=$'\t' read -r queue_green queue_yellow queue_red queue_white queue_error queue_gated <<<"$rollup"
+    if [ $(( queue_green + queue_yellow + queue_red + queue_white + queue_error + queue_gated )) -gt 0 ]; then
+      queue_segment="🟢 $queue_green  🟡 $queue_yellow  🔴 $queue_red  ⚪ $queue_white"
+      [ "$queue_error" -gt 0 ] && queue_segment="$queue_segment  🟠 $queue_error"
+      [ "$queue_gated" -gt 0 ] && queue_segment="$queue_segment  ⚠️ $queue_gated"
+      parts+=("$queue_segment")
+    fi
+  fi
+fi
+
+printf '%s' "${parts[0]}"
+for index in "${!parts[@]}"; do
+  [ "$index" -eq 0 ] && continue
+  printf ' | %s' "${parts[$index]}"
+done
+printf '\n'

--- a/dotfiles/agent-config.d/claude/statusline-command.sh
+++ b/dotfiles/agent-config.d/claude/statusline-command.sh
@@ -37,14 +37,45 @@ IFS=$'\037' read -r \
   ] | map(tostring) | join("\u001f")')"
 
 # Leave a per-project context-pressure breadcrumb for prrq and other local
-# helpers. Readers treat a missing or stale file as unknown.
+# helpers. Readers treat a missing or stale file as unknown. The state directory
+# is private to the current user, and the replace path never writes through a
+# pre-existing symlink.
 sid=$(printf '%s' "$input" | jq -r '.session_id // ""')
 pdir=$(printf '%s' "$input" | jq -r '.workspace.project_dir // .workspace.current_dir // .cwd // ""')
-if [ -n "$used_pct" ] && [ -n "$pdir" ]; then
+if [ -n "$used_pct" ] && [ -n "$pdir" ] && [ -n "${HOME:-}" ]; then
   proot=$(git -C "$pdir" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$pdir")
   pkey=$(printf '%s' "$proot" | { md5 -q 2>/dev/null || md5sum | cut -d' ' -f1; } | cut -c1-12)
-  printf '%.0f %s %s\n' "$used_pct" "${sid:-unknown}" "$(date +%s)" \
-    >"${TMPDIR:-/tmp}/claude-ctx-$pkey.breadcrumb" 2>/dev/null
+  (
+    umask 077
+    breadcrumb_dir="$HOME/.local/state/claude-statusline"
+    mkdir -p "$breadcrumb_dir" || exit 0
+    [ -d "$breadcrumb_dir" ] && [ ! -L "$breadcrumb_dir" ] || exit 0
+
+    if stat -f '%u' "$breadcrumb_dir" >/dev/null 2>&1; then
+      breadcrumb_uid=$(stat -f '%u' "$breadcrumb_dir" 2>/dev/null)
+    else
+      breadcrumb_uid=$(stat -c '%u' "$breadcrumb_dir" 2>/dev/null) || exit 0
+    fi
+    [ "$breadcrumb_uid" = "$(id -u)" ] || exit 0
+    chmod 700 "$breadcrumb_dir" || exit 0
+
+    breadcrumb="$breadcrumb_dir/claude-ctx-$pkey.breadcrumb"
+    breadcrumb_tmp=$(mktemp "$breadcrumb_dir/.claude-ctx-$pkey.XXXXXX") || exit 0
+    trap 'rm -f "$breadcrumb_tmp"' EXIT
+    printf '%.0f %s %s\n' "$used_pct" "${sid:-unknown}" "$(date +%s)" \
+      >"$breadcrumb_tmp" || exit 0
+    chmod 600 "$breadcrumb_tmp" || exit 0
+
+    # The private directory prevents a post-check race by another user. Remove
+    # a pre-existing link itself; never open its destination.
+    if [ -L "$breadcrumb" ]; then
+      rm -f "$breadcrumb" || exit 0
+    elif [ -e "$breadcrumb" ] && [ ! -f "$breadcrumb" ]; then
+      exit 0
+    fi
+    mv -f "$breadcrumb_tmp" "$breadcrumb" || exit 0
+    trap - EXIT
+  ) 2>/dev/null
 fi
 
 # Compact reset suffix: middle-dot plus days, hours, or minutes.

--- a/dotfiles/agent-config.d/claude/statusline-command.sh
+++ b/dotfiles/agent-config.d/claude/statusline-command.sh
@@ -117,38 +117,32 @@ else
   parts+=("$(basename "$cwd")")
 fi
 
-# Read the queue directly. This is deliberately lock-free and read-only: a
-# status-line render must never contend with prrq's queue writer.
-prrq_home="${PRRQ_HOME:-}"
-if [ -z "$prrq_home" ]; then
-  prrq_config="${PRRQ_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/prrq/config}"
-  [ -f "$prrq_config" ] && prrq_home=$(grep -E '^[[:space:]]*PRRQ_HOME=' "$prrq_config" 2>/dev/null | tail -1 | sed 's/^[^=]*=//')
-fi
-prrq_home="${prrq_home:-$HOME/.prrq}"
-case "$prrq_home" in
-  \~/*) prrq_home="$HOME/${prrq_home#\~/}" ;;
-esac
-
-queue="$prrq_home/queue.json"
-if [ -f "$queue" ]; then
-  rollup=$(jq -r '
-    [.items[] | select(.status != "merged" and .status != "closed")] as $open
-    | ($open | map(select(.status == "approved" or .status == "agent_approved"
-                         or .status == "human_ready" or .status == "reviewed"))) as $green
-    | ($green | map(select(.mergeable == "CONFLICTING"
-                           or .ci_state == "FAILURE" or .ci_state == "ERROR")) | length) as $gated
-    | [ (($green | length) - $gated),
-        ($open | map(select(.status == "changed")) | length),
-        ($open | map(select(.status == "changes_requested")) | length),
-        ($open | map(select(.status == "needs_review")) | length),
-        ($open | map(select(.status == "error")) | length),
-        $gated ] | @tsv' "$queue" 2>/dev/null)
+# Ask prrq to interpret its own state through the JSON summary contract added in
+# prrq#45. Missing or older installations simply omit this
+# optional segment; reaching into queue.json would couple this renderer to
+# prrq's private storage schema all over again.
+if command -v prrq >/dev/null 2>&1; then
+  summary=$(prrq summary --json 2>/dev/null) || summary=""
+  rollup=""
+  if [ -n "$summary" ]; then
+    rollup=$(printf '%s' "$summary" | jq -er '
+      select(.schema_version == 1)
+      | [ .counts.approved, .counts.changed, .counts.changes_requested,
+          .counts.needs_review, .counts.error, .counts.gated,
+          .counts.claimed, .counts.blocked ]
+      | select(all(.[]; type == "number" and . >= 0 and floor == .))
+      | @tsv' 2>/dev/null) || rollup=""
+  fi
   if [ -n "$rollup" ]; then
-    IFS=$'\t' read -r queue_green queue_yellow queue_red queue_white queue_error queue_gated <<<"$rollup"
-    if [ $(( queue_green + queue_yellow + queue_red + queue_white + queue_error + queue_gated )) -gt 0 ]; then
+    IFS=$'\t' read -r \
+      queue_green queue_yellow queue_red queue_white queue_error queue_gated \
+      queue_claimed queue_blocked <<<"$rollup"
+    if [ $(( queue_green + queue_yellow + queue_red + queue_white + queue_error + queue_gated + queue_claimed + queue_blocked )) -gt 0 ]; then
       queue_segment="🟢 $queue_green  🟡 $queue_yellow  🔴 $queue_red  ⚪ $queue_white"
       [ "$queue_error" -gt 0 ] && queue_segment="$queue_segment  🟠 $queue_error"
       [ "$queue_gated" -gt 0 ] && queue_segment="$queue_segment  ⚠️ $queue_gated"
+      [ "$queue_claimed" -gt 0 ] && queue_segment="$queue_segment  🔒 $queue_claimed"
+      [ "$queue_blocked" -gt 0 ] && queue_segment="$queue_segment  🚫 $queue_blocked"
       parts+=("$queue_segment")
     fi
   fi

--- a/dotfiles/agent-config.d/codex/50-status-line.toml
+++ b/dotfiles/agent-config.d/codex/50-status-line.toml
@@ -1,0 +1,15 @@
+# Codex has a native status line. These identifiers are rendered in order.
+# Unlike Claude Code's command status line, Codex does not currently accept
+# arbitrary commands here, so cost estimates and the prrq rollup are omitted.
+[tui]
+status_line = [
+  "model",
+  "reasoning",
+  "fast-mode",
+  "context-used",
+  "five-hour-limit",
+  "weekly-limit",
+  "pull-request-number",
+  "branch-changes",
+  "project-name",
+]

--- a/dotfiles/helpers/install_agent_config.py
+++ b/dotfiles/helpers/install_agent_config.py
@@ -251,11 +251,17 @@ def atomic_write(path: Path, content: str) -> bool:
     return True
 
 
-def ensure_symlink(source: Path, destination: Path) -> bool:
-    source = source.resolve(strict=True)
-    destination.parent.mkdir(parents=True, exist_ok=True)
+def plan_symlink(
+    source: Path, destination: Path
+) -> tuple[Path, Path, str, Path | None]:
+    """Validate a renderer update without changing the filesystem."""
+    try:
+        source = source.resolve(strict=True)
+    except OSError as exc:
+        raise SafetyError(f"cannot resolve renderer source {source}: {exc}") from exc
+
     if destination.is_symlink() and os.readlink(destination) == str(source):
-        return False
+        return source, destination, "unchanged", None
 
     if os.path.lexists(destination):
         backup = destination.with_name(destination.name + ".pre-agent-config")
@@ -269,9 +275,26 @@ def ensure_symlink(source: Path, destination: Path) -> bool:
                 raise SafetyError(
                     f"refusing to replace {destination}; backup already exists at {backup}"
                 )
-            destination.unlink()
-        else:
-            os.replace(destination, backup)
+            return source, destination, "remove", None
+        return source, destination, "backup", backup
+
+    return source, destination, "link", None
+
+
+def apply_symlink(plan: tuple[Path, Path, str, Path | None]) -> bool:
+    """Apply a preflighted renderer update."""
+    source, destination, action, backup = plan
+    if action == "unchanged":
+        return False
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if action == "backup":
+        assert backup is not None
+        os.replace(destination, backup)
+    elif action == "remove":
+        destination.unlink()
+    elif action != "link":
+        raise RuntimeError(f"unknown renderer plan action: {action}")
 
     destination.symlink_to(source)
     return True
@@ -295,13 +318,14 @@ def main() -> int:
     codex_target, codex_content = plan_codex_config(
         args.home, fragments_root / "codex"
     )
-
-    claude_changed = atomic_write(claude_target, claude_content)
-    codex_changed = atomic_write(codex_target, codex_content)
-    renderer_changed = ensure_symlink(
+    renderer_plan = plan_symlink(
         fragments_root / "claude" / "statusline-command.sh",
         args.home / ".claude" / "statusline-command.sh",
     )
+
+    claude_changed = atomic_write(claude_target, claude_content)
+    codex_changed = atomic_write(codex_target, codex_content)
+    renderer_changed = apply_symlink(renderer_plan)
 
     print(
         "Agent status config: "

--- a/dotfiles/helpers/install_agent_config.py
+++ b/dotfiles/helpers/install_agent_config.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Install Claude and Codex config.d fragments without replacing user config."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import tempfile
+import tomllib
+from typing import Any
+
+
+class SafetyError(RuntimeError):
+    """Raised when an install would risk replacing unparseable user data."""
+
+
+def deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge objects; fragment scalars and arrays replace targets."""
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def require_regular_target(path: Path) -> None:
+    if path.is_symlink():
+        raise SafetyError(
+            f"refusing to replace symlinked config {path}; merge its target explicitly"
+        )
+    if path.exists() and not path.is_file():
+        raise SafetyError(f"refusing to replace non-file config {path}")
+
+
+def read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SafetyError(f"cannot parse {label} as JSON: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SafetyError(f"{label} must contain a JSON object: {path}")
+    return value
+
+
+def plan_claude_config(home: Path, fragments_dir: Path) -> tuple[Path, str]:
+    target = home / ".claude" / "settings.json"
+    require_regular_target(target)
+    merged: dict[str, Any]
+    if target.exists():
+        merged = read_json_object(target, label="Claude settings")
+    else:
+        merged = {}
+
+    fragments = sorted(fragments_dir.glob("*.json"))
+    if not fragments:
+        raise SafetyError(f"no Claude JSON fragments found in {fragments_dir}")
+    for fragment_path in fragments:
+        fragment = read_json_object(fragment_path, label="Claude config fragment")
+        merged = deep_merge(merged, fragment)
+
+    return target, json.dumps(merged, indent=2, ensure_ascii=False) + "\n"
+
+
+def load_codex_status_line(fragments_dir: Path) -> list[str]:
+    fragments = sorted(fragments_dir.glob("*.toml"))
+    if not fragments:
+        raise SafetyError(f"no Codex TOML fragments found in {fragments_dir}")
+
+    status_line: list[str] | None = None
+    for fragment_path in fragments:
+        try:
+            fragment = tomllib.loads(fragment_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise SafetyError(
+                f"cannot parse Codex config fragment {fragment_path}: {exc}"
+            ) from exc
+
+        if set(fragment) != {"tui"} or not isinstance(fragment["tui"], dict):
+            raise SafetyError(
+                f"Codex fragment may only contain the [tui] table: {fragment_path}"
+            )
+        if set(fragment["tui"]) != {"status_line"}:
+            raise SafetyError(
+                "Codex fragment may only set tui.status_line: " f"{fragment_path}"
+            )
+        candidate = fragment["tui"]["status_line"]
+        if not isinstance(candidate, list) or not all(
+            isinstance(item, str) and item for item in candidate
+        ):
+            raise SafetyError(
+                f"tui.status_line must be an array of non-empty strings: {fragment_path}"
+            )
+        status_line = candidate
+
+    assert status_line is not None
+    return status_line
+
+
+TABLE_HEADER_RE = re.compile(r"^\s*\[\[?[^]]+\]\]?\s*(?:#.*)?$")
+TUI_HEADER_RE = re.compile(r"^\s*\[tui\]\s*(?:#.*)?$")
+STATUS_LINE_RE = re.compile(r"^(?P<indent>\s*)status_line\s*=")
+
+
+def bracket_delta(line: str) -> int:
+    """Count TOML array brackets outside quoted strings and comments."""
+    delta = 0
+    quote: str | None = None
+    escaped = False
+    for char in line:
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quote = None
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            continue
+        if char == "#":
+            break
+        if char in {'"', "'"}:
+            quote = char
+        elif char == "[":
+            delta += 1
+        elif char == "]":
+            delta -= 1
+    return delta
+
+
+def render_status_line(status_line: list[str], indent: str = "") -> list[str]:
+    lines = [f"{indent}status_line = [\n"]
+    lines.extend(
+        f"{indent}  {json.dumps(item, ensure_ascii=False)},\n"
+        for item in status_line
+    )
+    lines.append(f"{indent}]\n")
+    return lines
+
+
+def merge_codex_status_line(original: str, status_line: list[str]) -> str:
+    lines = original.splitlines(keepends=True)
+    tui_index = next(
+        (index for index, line in enumerate(lines) if TUI_HEADER_RE.match(line.rstrip("\n"))),
+        None,
+    )
+
+    if tui_index is None:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        if lines and lines[-1].strip():
+            lines.append("\n")
+        lines.append("[tui]\n")
+        lines.extend(render_status_line(status_line))
+        return "".join(lines)
+
+    table_end = len(lines)
+    for index in range(tui_index + 1, len(lines)):
+        if TABLE_HEADER_RE.match(lines[index].rstrip("\n")):
+            table_end = index
+            break
+
+    existing_index: int | None = None
+    existing_end: int | None = None
+    indent = ""
+    for index in range(tui_index + 1, table_end):
+        match = STATUS_LINE_RE.match(lines[index])
+        if not match:
+            continue
+        existing_index = index
+        indent = match.group("indent")
+        depth = bracket_delta(lines[index].split("=", 1)[1])
+        existing_end = index + 1
+        while depth > 0 and existing_end < table_end:
+            depth += bracket_delta(lines[existing_end])
+            existing_end += 1
+        if depth != 0:
+            raise SafetyError("could not find the end of existing tui.status_line")
+        break
+
+    replacement = render_status_line(status_line, indent)
+    if existing_index is not None and existing_end is not None:
+        lines[existing_index:existing_end] = replacement
+    else:
+        insert_at = tui_index + 1
+        lines[insert_at:insert_at] = replacement
+    return "".join(lines)
+
+
+def plan_codex_config(home: Path, fragments_dir: Path) -> tuple[Path, str]:
+    target = home / ".codex" / "config.toml"
+    require_regular_target(target)
+    original = target.read_text(encoding="utf-8") if target.exists() else ""
+    if original:
+        try:
+            tomllib.loads(original)
+        except tomllib.TOMLDecodeError as exc:
+            raise SafetyError(f"cannot parse Codex config {target}: {exc}") from exc
+
+    status_line = load_codex_status_line(fragments_dir)
+    merged = merge_codex_status_line(original, status_line)
+    try:
+        parsed = tomllib.loads(merged)
+    except tomllib.TOMLDecodeError as exc:
+        raise SafetyError(
+            f"refusing to write invalid merged Codex config {target}: {exc}"
+        ) from exc
+    if parsed.get("tui", {}).get("status_line") != status_line:
+        raise SafetyError("merged Codex config did not retain the requested status line")
+    return target, merged
+
+
+def backup_once(path: Path) -> None:
+    if not path.exists():
+        return
+    backup = path.with_name(path.name + ".pre-agent-config")
+    if not backup.exists() and not backup.is_symlink():
+        shutil.copy2(path, backup)
+
+
+def atomic_write(path: Path, content: str) -> bool:
+    old_content = path.read_text(encoding="utf-8") if path.exists() else None
+    if old_content == content:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup_once(path)
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
+    handle, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return True
+
+
+def ensure_symlink(source: Path, destination: Path) -> bool:
+    source = source.resolve(strict=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.is_symlink() and os.readlink(destination) == str(source):
+        return False
+
+    if os.path.lexists(destination):
+        backup = destination.with_name(destination.name + ".pre-agent-config")
+        same_regular_file = (
+            destination.is_file()
+            and not destination.is_symlink()
+            and destination.read_bytes() == source.read_bytes()
+        )
+        if os.path.lexists(backup):
+            if not same_regular_file:
+                raise SafetyError(
+                    f"refusing to replace {destination}; backup already exists at {backup}"
+                )
+            destination.unlink()
+        else:
+            os.replace(destination, backup)
+
+    destination.symlink_to(source)
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dotfiles-dir", type=Path, required=True)
+    parser.add_argument("--home", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    fragments_root = args.dotfiles_dir / "agent-config.d"
+
+    # Plan and validate every config before modifying any of them.
+    claude_target, claude_content = plan_claude_config(
+        args.home, fragments_root / "claude"
+    )
+    codex_target, codex_content = plan_codex_config(
+        args.home, fragments_root / "codex"
+    )
+
+    claude_changed = atomic_write(claude_target, claude_content)
+    codex_changed = atomic_write(codex_target, codex_content)
+    renderer_changed = ensure_symlink(
+        fragments_root / "claude" / "statusline-command.sh",
+        args.home / ".claude" / "statusline-command.sh",
+    )
+
+    print(
+        "Agent status config: "
+        f"Claude {'updated' if claude_changed else 'unchanged'}, "
+        f"Codex {'updated' if codex_changed else 'unchanged'}, "
+        f"renderer {'linked' if renderer_changed else 'unchanged'}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SafetyError as exc:
+        raise SystemExit(f"Error: {exc}") from exc

--- a/init.sh
+++ b/init.sh
@@ -136,6 +136,14 @@ if ! command -v jq >/dev/null 2>&1; then
     fi
 fi
 
+# Python is installed by run.sh on a fresh machine. If it is already available,
+# install agent status config now; otherwise run.sh performs this step later.
+if command -v python3 >/dev/null 2>&1; then
+    "$DOTFILES_CHECKOUT/installation/agent-config.sh"
+else
+    echo "Deferring Claude/Codex status-line config until run.sh installs Python."
+fi
+
 echo "Ensure authorized keys are synced to local authorized_keys..."
 mkdir -p $SSH_DIR
 # we want to be able to run this and update the authorized keys with whatever we have on GH

--- a/init.sh
+++ b/init.sh
@@ -136,13 +136,9 @@ if ! command -v jq >/dev/null 2>&1; then
     fi
 fi
 
-# Python is installed by run.sh on a fresh machine. If it is already available,
-# install agent status config now; otherwise run.sh performs this step later.
-if command -v python3 >/dev/null 2>&1; then
-    "$DOTFILES_CHECKOUT/installation/agent-config.sh"
-else
-    echo "Deferring Claude/Codex status-line config until run.sh installs Python."
-fi
+# This optional step selects Python 3.11+ when available and otherwise defers
+# without stopping the rest of the bootstrap.
+"$DOTFILES_CHECKOUT/installation/agent-config.sh"
 
 echo "Ensure authorized keys are synced to local authorized_keys..."
 mkdir -p $SSH_DIR

--- a/installation/agent-config.sh
+++ b/installation/agent-config.sh
@@ -5,11 +5,37 @@ set -euo pipefail
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 dotfiles_dir=$(cd "$script_dir/../dotfiles" && pwd)
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is required to merge agent config fragments safely." >&2
-  exit 1
+if [ -n "${PYTHON3_BIN:-}" ]; then
+  python_candidates=("$PYTHON3_BIN")
+else
+  python_candidates=(
+    python3
+    python3.14
+    python3.13
+    python3.12
+    python3.11
+    /opt/homebrew/bin/python3
+    /usr/local/bin/python3
+  )
 fi
 
-exec python3 "$dotfiles_dir/helpers/install_agent_config.py" \
+python_bin=""
+for candidate in "${python_candidates[@]}"; do
+  command -v "$candidate" >/dev/null 2>&1 || continue
+  if "$candidate" -c \
+    'import sys, tomllib; raise SystemExit(sys.version_info < (3, 11))' \
+    >/dev/null 2>&1; then
+    python_bin="$candidate"
+    break
+  fi
+done
+
+if [ -z "$python_bin" ]; then
+  echo "Skipping optional Claude/Codex status-line config: Python 3.11+ with tomllib is unavailable." >&2
+  echo "Re-run installation/agent-config.sh after installing a compatible Python." >&2
+  exit 0
+fi
+
+exec "$python_bin" "$dotfiles_dir/helpers/install_agent_config.py" \
   --dotfiles-dir "$dotfiles_dir" \
   --home "$HOME"

--- a/installation/agent-config.sh
+++ b/installation/agent-config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+dotfiles_dir=$(cd "$script_dir/../dotfiles" && pwd)
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 is required to merge agent config fragments safely." >&2
+  exit 1
+fi
+
+exec python3 "$dotfiles_dir/helpers/install_agent_config.py" \
+  --dotfiles-dir "$dotfiles_dir" \
+  --home "$HOME"

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ echo_green "Installing applications..."
 echo_cyan "About to run '$DOTFILES_CHECKOUT/installation/all.sh'."
 $DOTFILES_CHECKOUT/installation/all.sh
 
-echo_cyan "Installing Claude and Codex status-line configuration..."
+echo_cyan "Configuring optional Claude and Codex status lines..."
 $DOTFILES_CHECKOUT/installation/agent-config.sh
 
 echo "*******************************************"

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,9 @@ echo_green "Installing applications..."
 echo_cyan "About to run '$DOTFILES_CHECKOUT/installation/all.sh'."
 $DOTFILES_CHECKOUT/installation/all.sh
 
+echo_cyan "Installing Claude and Codex status-line configuration..."
+$DOTFILES_CHECKOUT/installation/agent-config.sh
+
 echo "*******************************************"
 echo "Intial setup complete!"
 echo "To finish setup, restart your shell."

--- a/tests/test-agent-config.sh
+++ b/tests/test-agent-config.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+installer="$repo_root/installation/agent-config.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+test_home="$test_root/home"
+mkdir -p "$test_home/.claude" "$test_home/.codex"
+
+cat >"$test_home/.claude/settings.json" <<'JSON'
+{
+  "permissions": {
+    "allow": ["Bash(git status:*)"]
+  },
+  "hooks": {
+    "Stop": [{"hooks": [{"type": "command", "command": "keep-me"}]}]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "old-status-command"
+  },
+  "sentinel": "claude-settings-survived"
+}
+JSON
+
+cat >"$test_home/.codex/config.toml" <<'TOML'
+# preserve-this-comment
+model = "sentinel-model"
+
+[features]
+hooks = true
+
+[tui]
+pet = "null-signal"
+status_line = [
+  "current-dir",
+]
+notifications = ["agent-turn-complete"]
+
+[projects."/tmp/sentinel"]
+trust_level = "trusted"
+TOML
+
+printf '%s\n' 'local-renderer-that-must-be-backed-up' \
+  >"$test_home/.claude/statusline-command.sh"
+
+HOME="$test_home" "$installer"
+
+jq -e '.sentinel == "claude-settings-survived"' \
+  "$test_home/.claude/settings.json" >/dev/null
+jq -e '.permissions.allow == ["Bash(git status:*)"]' \
+  "$test_home/.claude/settings.json" >/dev/null
+jq -e '.hooks.Stop[0].hooks[0].command == "keep-me"' \
+  "$test_home/.claude/settings.json" >/dev/null
+jq -e '.statusLine.command == "bash \"$HOME/.claude/statusline-command.sh\""' \
+  "$test_home/.claude/settings.json" >/dev/null
+
+python3 - "$test_home/.codex/config.toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    config = tomllib.load(handle)
+
+expected = [
+    "model",
+    "reasoning",
+    "fast-mode",
+    "context-used",
+    "five-hour-limit",
+    "weekly-limit",
+    "pull-request-number",
+    "branch-changes",
+    "project-name",
+]
+assert config["model"] == "sentinel-model"
+assert config["features"]["hooks"] is True
+assert config["tui"]["pet"] == "null-signal"
+assert config["tui"]["notifications"] == ["agent-turn-complete"]
+assert config["tui"]["status_line"] == expected
+assert config["projects"]["/tmp/sentinel"]["trust_level"] == "trusted"
+PY
+
+grep -F '# preserve-this-comment' "$test_home/.codex/config.toml" >/dev/null
+[ -L "$test_home/.claude/statusline-command.sh" ] || fail "renderer is not a symlink"
+[ "$(readlink "$test_home/.claude/statusline-command.sh")" = \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" ] || \
+  fail "renderer symlink points to the wrong source"
+grep -F 'local-renderer-that-must-be-backed-up' \
+  "$test_home/.claude/statusline-command.sh.pre-agent-config" >/dev/null
+
+cp "$test_home/.claude/settings.json" "$test_root/claude-first.json"
+cp "$test_home/.codex/config.toml" "$test_root/codex-first.toml"
+HOME="$test_home" "$installer"
+cmp "$test_root/claude-first.json" "$test_home/.claude/settings.json" || \
+  fail "second run changed Claude settings"
+cmp "$test_root/codex-first.toml" "$test_home/.codex/config.toml" || \
+  fail "second run changed Codex config"
+
+# A missing [tui] table is appended without changing existing top-level data.
+no_tui_home="$test_root/no-tui-home"
+mkdir -p "$no_tui_home/.claude" "$no_tui_home/.codex"
+printf '%s\n' '{"sentinel": "keep"}' >"$no_tui_home/.claude/settings.json"
+printf '%s\n' 'model = "keep-me"' >"$no_tui_home/.codex/config.toml"
+HOME="$no_tui_home" "$installer" >/dev/null
+python3 - "$no_tui_home/.codex/config.toml" <<'PY'
+import sys
+import tomllib
+with open(sys.argv[1], "rb") as handle:
+    config = tomllib.load(handle)
+assert config["model"] == "keep-me"
+assert config["tui"]["status_line"][0] == "model"
+PY
+
+# Invalid inputs abort before either agent config is touched.
+invalid_home="$test_root/invalid-home"
+mkdir -p "$invalid_home/.claude" "$invalid_home/.codex"
+printf '%s\n' '{ definitely not json' >"$invalid_home/.claude/settings.json"
+printf '%s\n' 'model = "untouched"' >"$invalid_home/.codex/config.toml"
+cp "$invalid_home/.claude/settings.json" "$test_root/invalid-before.json"
+cp "$invalid_home/.codex/config.toml" "$test_root/invalid-before.toml"
+if HOME="$invalid_home" "$installer" >/dev/null 2>&1; then
+  fail "installer accepted invalid Claude JSON"
+fi
+cmp "$test_root/invalid-before.json" "$invalid_home/.claude/settings.json" || \
+  fail "invalid Claude config was modified"
+cmp "$test_root/invalid-before.toml" "$invalid_home/.codex/config.toml" || \
+  fail "Codex config changed after Claude validation failed"
+
+invalid_toml_home="$test_root/invalid-toml-home"
+mkdir -p "$invalid_toml_home/.claude" "$invalid_toml_home/.codex"
+printf '%s\n' '{"sentinel": "untouched"}' \
+  >"$invalid_toml_home/.claude/settings.json"
+printf '%s\n' '[tui' >"$invalid_toml_home/.codex/config.toml"
+cp "$invalid_toml_home/.claude/settings.json" "$test_root/toml-claude-before.json"
+cp "$invalid_toml_home/.codex/config.toml" "$test_root/toml-before.toml"
+if HOME="$invalid_toml_home" "$installer" >/dev/null 2>&1; then
+  fail "installer accepted invalid Codex TOML"
+fi
+cmp "$test_root/toml-claude-before.json" \
+  "$invalid_toml_home/.claude/settings.json" || \
+  fail "Claude config changed after Codex validation failed"
+cmp "$test_root/toml-before.toml" "$invalid_toml_home/.codex/config.toml" || \
+  fail "invalid Codex config was modified"
+
+# Config symlinks are refused rather than replaced. This protects users who
+# already manage an agent's whole config through another dotfiles mechanism.
+symlink_home="$test_root/symlink-home"
+mkdir -p "$symlink_home/.claude" "$symlink_home/.codex"
+printf '%s\n' '{"sentinel": "external-config"}' >"$test_root/external.json"
+ln -s "$test_root/external.json" "$symlink_home/.claude/settings.json"
+printf '%s\n' 'model = "untouched"' >"$symlink_home/.codex/config.toml"
+if HOME="$symlink_home" "$installer" >/dev/null 2>&1; then
+  fail "installer replaced a symlinked config"
+fi
+grep -F 'external-config' "$test_root/external.json" >/dev/null
+[ -L "$symlink_home/.claude/settings.json" ] || \
+  fail "Claude config symlink was removed"
+
+# Render a representative Claude payload, including the prrq queue summary.
+mkdir -p "$test_root/prrq"
+cat >"$test_root/prrq/queue.json" <<'JSON'
+{
+  "items": [
+    {"status": "approved", "mergeable": "MERGEABLE", "ci_state": "SUCCESS"},
+    {"status": "changed"},
+    {"status": "changes_requested"},
+    {"status": "needs_review"}
+  ]
+}
+JSON
+rendered=$(jq -n '{
+  model: {display_name: "Opus 4", id: "claude-opus-4"},
+  context_window: {
+    used_percentage: 23,
+    total_input_tokens: 100000,
+    total_output_tokens: 10000
+  },
+  rate_limits: {
+    five_hour: {used_percentage: 1},
+    seven_day: {used_percentage: 95}
+  },
+  effort: {level: "high"},
+  exceeds_200k_tokens: true,
+  pr: {number: 23, review_state: "pending"},
+  workspace: {
+    repo: {owner: "example-org", name: "example-repo"},
+    current_dir: "/tmp/example-repo"
+  },
+  cost: {
+    total_cost_usd: 3.5,
+    total_lines_added: 12,
+    total_lines_removed: 3
+  }
+}' | PRRQ_HOME="$test_root/prrq" \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh")
+expected="Opus 4 | e:high | ctx:23%⚠ | 5h:1% | 7d:95% | PR#23 … | \$2.250 | Σ\$3.50 | Δ+12/-3 | example-org/example-repo | 🟢 1  🟡 1  🔴 1  ⚪ 1"
+[ "$rendered" = "$expected" ] || \
+  fail "unexpected Claude status line: $rendered"
+
+echo "PASS: agent config fragments merge safely and idempotently"

--- a/tests/test-agent-config.sh
+++ b/tests/test-agent-config.sh
@@ -12,6 +12,14 @@ fail() {
   exit 1
 }
 
+mode_of() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
 test_home="$test_root/home"
 mkdir -p "$test_home/.claude" "$test_home/.codex"
 
@@ -272,7 +280,20 @@ jq -n '{
 }' >"$test_root/claude-status-payload.json"
 
 status_base="Opus 4 | e:high | ctx:23%⚠ | 5h:1% | 7d:95% | PR#23 … | \$2.250 | Σ\$3.50 | Δ+12/-3 | example-org/example-repo"
-rendered=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+status_home="$test_root/status-home"
+breadcrumb_dir="$status_home/.local/state/claude-statusline"
+breadcrumb_key=$(printf '%s' '/tmp/example-repo' | \
+  { md5 -q 2>/dev/null || md5sum | cut -d' ' -f1; } | cut -c1-12)
+breadcrumb="$breadcrumb_dir/claude-ctx-$breadcrumb_key.breadcrumb"
+breadcrumb_victim="$test_root/breadcrumb-victim"
+mkdir -p "$breadcrumb_dir"
+chmod 755 "$breadcrumb_dir"
+printf '%s\n' 'must-not-be-overwritten' >"$breadcrumb_victim"
+cp "$breadcrumb_victim" "$test_root/breadcrumb-victim.before"
+ln -s "$breadcrumb_victim" "$breadcrumb"
+
+rendered=$(HOME="$status_home" \
+  PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   PRRQ_HOME="$test_root/prrq" \
   PRRQ_CALL_LOG="$test_root/prrq-call.log" \
   PRRQ_SUMMARY_FIXTURE="$test_root/prrq-summary.json" \
@@ -283,16 +304,36 @@ expected="$status_base | 🟢 1  🟡 1  🔴 1  ⚪ 1  🟠 1  ⚠️ 1  🔒 1
   fail "unexpected Claude status line: $rendered"
 [ "$(cat "$test_root/prrq-call.log")" = "summary --json" ] || \
   fail "renderer invoked the wrong prrq command"
+cmp -s "$test_root/breadcrumb-victim.before" "$breadcrumb_victim" || \
+  fail "breadcrumb write followed a planted symlink"
+[ -f "$breadcrumb" ] && [ ! -L "$breadcrumb" ] || \
+  fail "breadcrumb was not replaced with a regular file"
+[ "$(mode_of "$breadcrumb_dir")" = 700 ] || \
+  fail "breadcrumb directory is not private"
+[ "$(mode_of "$breadcrumb")" = 600 ] || \
+  fail "breadcrumb file is not private"
+grep -Eq '^23 unknown [0-9]+$' "$breadcrumb" || \
+  fail "breadcrumb content contract changed"
+
+jq '.context_window.used_percentage = 42 | .session_id = "fixture-session"' \
+  "$test_root/claude-status-payload.json" >"$test_root/claude-status-updated.json"
+HOME="$status_home" PATH="$test_root/base-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
+  <"$test_root/claude-status-updated.json" >/dev/null
+grep -Eq '^42 fixture-session [0-9]+$' "$breadcrumb" || \
+  fail "ordinary render did not update the private breadcrumb"
 
 # Missing, older, failing, or malformed prrq installations are optional and
 # must not break the rest of the status line.
-without_prrq=$(PATH="$test_root/base-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+without_prrq=$(HOME="$status_home" \
+  PATH="$test_root/base-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
   <"$test_root/claude-status-payload.json")
 [ "$without_prrq" = "$status_base" ] || \
   fail "missing prrq changed the Claude status line"
 
-failing_prrq=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+failing_prrq=$(HOME="$status_home" \
+  PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   PRRQ_CALL_LOG="$test_root/prrq-call.log" \
   PRRQ_SUMMARY_FIXTURE="$test_root/prrq-summary.json" \
   PRRQ_SUMMARY_FAIL=1 \
@@ -301,7 +342,8 @@ failing_prrq=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
 [ "$failing_prrq" = "$status_base" ] || \
   fail "failing prrq changed the Claude status line"
 
-invalid_prrq=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+invalid_prrq=$(HOME="$status_home" \
+  PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   PRRQ_CALL_LOG="$test_root/prrq-call.log" \
   PRRQ_SUMMARY_FIXTURE="$test_root/invalid-prrq-summary" \
   "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \

--- a/tests/test-agent-config.sh
+++ b/tests/test-agent-config.sh
@@ -15,6 +15,29 @@ fail() {
 test_home="$test_root/home"
 mkdir -p "$test_home/.claude" "$test_home/.codex"
 
+# The optional wrapper must not abort bootstrap under a system Python that lacks
+# tomllib. The explicit override makes the minimum-interpreter path deterministic
+# on CI hosts whose /usr/bin/python3 version varies.
+incompatible_python="$test_root/python-without-tomllib"
+cat >"$incompatible_python" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-c" ]; then
+  exit 1
+fi
+echo "incompatible interpreter was invoked after the capability check" >&2
+exit 99
+SH
+chmod +x "$incompatible_python"
+deferred_home="$test_root/deferred-home"
+deferred_output=$(HOME="$deferred_home" PYTHON3_BIN="$incompatible_python" \
+  "$installer" 2>&1) || fail "incompatible Python made the optional installer fail"
+grep -F 'Python 3.11+ with tomllib is unavailable' <<<"$deferred_output" >/dev/null || \
+  fail "incompatible Python did not produce the deferral notice"
+[ ! -e "$deferred_home/.claude/settings.json" ] || \
+  fail "deferred install wrote Claude settings"
+[ ! -e "$deferred_home/.codex/config.toml" ] || \
+  fail "deferred install wrote Codex config"
+
 cat >"$test_home/.claude/settings.json" <<'JSON'
 {
   "permissions": {
@@ -164,6 +187,41 @@ fi
 grep -F 'external-config' "$test_root/external.json" >/dev/null
 [ -L "$symlink_home/.claude/settings.json" ] || \
   fail "Claude config symlink was removed"
+
+# A renderer backup conflict is discovered before either config is written.
+renderer_conflict_home="$test_root/renderer-conflict-home"
+mkdir -p "$renderer_conflict_home/.claude" "$renderer_conflict_home/.codex"
+printf '%s\n' '{"sentinel": "claude-before-conflict"}' \
+  >"$renderer_conflict_home/.claude/settings.json"
+printf '%s\n' 'model = "codex-before-conflict"' \
+  >"$renderer_conflict_home/.codex/config.toml"
+printf '%s\n' 'renderer-owned-by-user' \
+  >"$renderer_conflict_home/.claude/statusline-command.sh"
+printf '%s\n' 'different-existing-backup' \
+  >"$renderer_conflict_home/.claude/statusline-command.sh.pre-agent-config"
+cp "$renderer_conflict_home/.claude/settings.json" \
+  "$test_root/renderer-conflict-claude-before.json"
+cp "$renderer_conflict_home/.codex/config.toml" \
+  "$test_root/renderer-conflict-codex-before.toml"
+if HOME="$renderer_conflict_home" "$installer" >/dev/null 2>&1; then
+  fail "installer accepted a conflicting renderer backup"
+fi
+cmp "$test_root/renderer-conflict-claude-before.json" \
+  "$renderer_conflict_home/.claude/settings.json" || \
+  fail "renderer conflict changed Claude settings before failure"
+cmp "$test_root/renderer-conflict-codex-before.toml" \
+  "$renderer_conflict_home/.codex/config.toml" || \
+  fail "renderer conflict changed Codex config before failure"
+grep -F 'renderer-owned-by-user' \
+  "$renderer_conflict_home/.claude/statusline-command.sh" >/dev/null || \
+  fail "renderer conflict changed the existing renderer"
+grep -F 'different-existing-backup' \
+  "$renderer_conflict_home/.claude/statusline-command.sh.pre-agent-config" >/dev/null || \
+  fail "renderer conflict changed the existing backup"
+[ ! -e "$renderer_conflict_home/.claude/settings.json.pre-agent-config" ] || \
+  fail "renderer conflict created a Claude backup before failing"
+[ ! -e "$renderer_conflict_home/.codex/config.toml.pre-agent-config" ] || \
+  fail "renderer conflict created a Codex backup before failing"
 
 # Render a representative Claude payload, including the prrq queue summary.
 mkdir -p "$test_root/prrq"

--- a/tests/test-agent-config.sh
+++ b/tests/test-agent-config.sh
@@ -223,19 +223,30 @@ grep -F 'different-existing-backup' \
 [ ! -e "$renderer_conflict_home/.codex/config.toml.pre-agent-config" ] || \
   fail "renderer conflict created a Codex backup before failing"
 
-# Render a representative Claude payload, including the prrq queue summary.
-mkdir -p "$test_root/prrq"
+# Render a representative Claude payload. The prrq fixture implements the
+# public summary contract from prrq#45; a poison queue file proves
+# the renderer never reaches into prrq's storage directly.
+mkdir -p "$test_root/prrq" "$test_root/status-bin" "$test_root/base-bin"
+ln -s "$(command -v jq)" "$test_root/status-bin/jq"
+ln -s "$(command -v jq)" "$test_root/base-bin/jq"
+cat >"$test_root/status-bin/prrq" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${PRRQ_CALL_LOG:?}"
+[ "$#" -eq 2 ] && [ "$1" = summary ] && [ "$2" = --json ] || exit 64
+[ -z "${PRRQ_SUMMARY_FAIL:-}" ] || exit 2
+cat "${PRRQ_SUMMARY_FIXTURE:?}"
+SH
+chmod +x "$test_root/status-bin/prrq"
+
 cat >"$test_root/prrq/queue.json" <<'JSON'
-{
-  "items": [
-    {"status": "approved", "mergeable": "MERGEABLE", "ci_state": "SUCCESS"},
-    {"status": "changed"},
-    {"status": "changes_requested"},
-    {"status": "needs_review"}
-  ]
-}
+{"items":[{"status":"needs_review"},{"status":"needs_review"}]}
 JSON
-rendered=$(jq -n '{
+cat >"$test_root/prrq-summary.json" <<'JSON'
+{"schema_version":1,"open":7,"counts":{"approved":1,"changed":1,"changes_requested":1,"needs_review":1,"error":1,"gated":1,"claimed":1,"blocked":1}}
+JSON
+printf '%s\n' 'not-json' >"$test_root/invalid-prrq-summary"
+
+jq -n '{
   model: {display_name: "Opus 4", id: "claude-opus-4"},
   context_window: {
     used_percentage: 23,
@@ -258,10 +269,44 @@ rendered=$(jq -n '{
     total_lines_added: 12,
     total_lines_removed: 3
   }
-}' | PRRQ_HOME="$test_root/prrq" \
-  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh")
-expected="Opus 4 | e:high | ctx:23%⚠ | 5h:1% | 7d:95% | PR#23 … | \$2.250 | Σ\$3.50 | Δ+12/-3 | example-org/example-repo | 🟢 1  🟡 1  🔴 1  ⚪ 1"
+}' >"$test_root/claude-status-payload.json"
+
+status_base="Opus 4 | e:high | ctx:23%⚠ | 5h:1% | 7d:95% | PR#23 … | \$2.250 | Σ\$3.50 | Δ+12/-3 | example-org/example-repo"
+rendered=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  PRRQ_HOME="$test_root/prrq" \
+  PRRQ_CALL_LOG="$test_root/prrq-call.log" \
+  PRRQ_SUMMARY_FIXTURE="$test_root/prrq-summary.json" \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
+  <"$test_root/claude-status-payload.json")
+expected="$status_base | 🟢 1  🟡 1  🔴 1  ⚪ 1  🟠 1  ⚠️ 1  🔒 1  🚫 1"
 [ "$rendered" = "$expected" ] || \
   fail "unexpected Claude status line: $rendered"
+[ "$(cat "$test_root/prrq-call.log")" = "summary --json" ] || \
+  fail "renderer invoked the wrong prrq command"
+
+# Missing, older, failing, or malformed prrq installations are optional and
+# must not break the rest of the status line.
+without_prrq=$(PATH="$test_root/base-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
+  <"$test_root/claude-status-payload.json")
+[ "$without_prrq" = "$status_base" ] || \
+  fail "missing prrq changed the Claude status line"
+
+failing_prrq=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  PRRQ_CALL_LOG="$test_root/prrq-call.log" \
+  PRRQ_SUMMARY_FIXTURE="$test_root/prrq-summary.json" \
+  PRRQ_SUMMARY_FAIL=1 \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
+  <"$test_root/claude-status-payload.json")
+[ "$failing_prrq" = "$status_base" ] || \
+  fail "failing prrq changed the Claude status line"
+
+invalid_prrq=$(PATH="$test_root/status-bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  PRRQ_CALL_LOG="$test_root/prrq-call.log" \
+  PRRQ_SUMMARY_FIXTURE="$test_root/invalid-prrq-summary" \
+  "$repo_root/dotfiles/agent-config.d/claude/statusline-command.sh" \
+  <"$test_root/claude-status-payload.json")
+[ "$invalid_prrq" = "$status_base" ] || \
+  fail "invalid prrq JSON changed the Claude status line"
 
 echo "PASS: agent config fragments merge safely and idempotently"


### PR DESCRIPTION
## Summary

- add config.d-style Claude and Codex status-line fragments
- merge fragments into existing agent configs without replacing unrelated settings
- wire installation into the dotfiles bootstrap and rerun paths
- add preservation, malformed-config, symlink-refusal, idempotency, and renderer tests

## Safety and compatibility

The installer validates every existing JSON/TOML config and every fragment before writing either agent config. It deep-merges Claude JSON, narrowly updates only `tui.status_line` in Codex TOML, refuses symlinked config targets, writes atomically, and creates one-time pre-agent-config backups.

Claude uses the custom renderer shown in the documentation. Codex uses its native status-line item identifiers because Codex does not expose Claude's arbitrary status command hook.

## Public-repository audit

- scanned only the staged added lines for personal handles, local home paths, email addresses, private-key headers, common credential/token formats, and suspicious long encoded values
- replaced the renderer test's real account/repository fixture with `example-org/example-repo`
- configured this commit with the authenticated GitHub no-reply author address
- confirmed the staged file list contains only the nine intended dotfiles changes

No personal data or secrets were found in the proposed content.

## Verification

- `bash -n` on the changed shell entrypoints
- `shellcheck` on the new shell scripts
- `bash tests/test-agent-config.sh`
- `git diff --cached --check`

## Dependency

The Claude queue-rollup portion of this PR depends on [JonathanPorta/prrq#45](https://github.com/JonathanPorta/prrq/pull/45), which provides the read-only `prrq summary --json` contract. The renderer feature-detects that command and omits only the optional queue segment when `prrq` is missing or older.
