### PR TITLE
feat: Sync Codex Completion Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ After `init.sh` completes, restart your shell and run `run.sh` (see below).
 
 | | |
 |---|---|
-| **Purpose** | Installs applications and dev tools: oh-my-zsh + plugins, vim, gpg, git-lfs, gh CLI, ruby, python, node, and more via Homebrew (macOS) or dnf (Fedora). Re-runs symlinks first, then installs Claude and Codex status-line fragments. |
+| **Purpose** | Installs applications and dev tools: oh-my-zsh + plugins, vim, gpg, git-lfs, gh CLI, ruby, python, node, and more via Homebrew (macOS) or dnf (Fedora). Re-runs symlinks first, then installs Claude and Codex agent-config fragments. |
 | **Idempotency** | **Safe to re-run.** Package managers skip already-installed packages. Agent config is validated and only rewritten when the merged result changes. |
 | **Destructive?** | Re-runs `symlink.sh` (same backup behavior as `init.sh`). Agent config preserves unrelated keys and creates one `*.pre-agent-config` recovery copy before its first change. |
 
@@ -121,7 +121,7 @@ zsh -lc "$HOME/devel/$USER/dotfiles/run.sh"
 
 ---
 
-## Agent status lines
+## Agent configuration
 
 `init.sh` and `run.sh` invoke `installation/agent-config.sh`. The wrapper selects
 an available Python 3.11+ interpreter (required for the standard-library TOML
@@ -137,7 +137,8 @@ dotfiles/agent-config.d/
 │   ├── 50-status-line.json
 │   └── statusline-command.sh
 └── codex/
-    └── 50-status-line.toml
+    ├── 50-status-line.toml
+    └── 60-notifications.toml
 ```
 
 - Claude JSON fragments are deep-merged into `~/.claude/settings.json`; keys
@@ -149,20 +150,25 @@ dotfiles/agent-config.d/
   Context-pressure breadcrumbs use the stable
   `~/.local/state/claude-statusline/claude-ctx-<project-hash>.breadcrumb` reader
   contract inside a mode-`0700` directory; each breadcrumb is mode `0600`.
-- Codex TOML fragments currently support the deliberately narrow
-  `tui.status_line` setting. The installer updates that key inside the existing
-  `[tui]` table while preserving the rest of `~/.codex/config.toml` byte for
-  byte. Codex's native footer covers model, reasoning effort, context, 5-hour
-  and weekly usage, pull request number, branch changes, and project name.
+- Codex TOML fragments support a deliberately narrow allowlist:
+  `tui.status_line`, `tui.notifications`, and `tui.notification_condition`.
+  The installer updates only those keys inside the existing `[tui]` table while
+  preserving the rest of `~/.codex/config.toml` byte for byte. It applies Codex
+  fragments only when a `codex` executable is available on `PATH`; otherwise,
+  Codex config is left entirely untouched. The notification policy alerts on
+  `agent-turn-complete` while the terminal is unfocused, avoiding the
+  `approval-requested` noise produced while Auto-review is handling a request.
+  Codex's native footer covers model, reasoning effort, context, 5-hour and
+  weekly usage, pull request number, branch changes, and project name.
 - Codex does not currently allow custom status-line commands, so Claude's cost
   figures and `prrq` queue rollup cannot be added to the Codex footer through
   configuration. Unsupported data is omitted instead of being scraped from
   session logs.
 
-Before either config is written, both existing configs, all fragments, and the
+Before any selected config is written, existing configs, fragments, and the
 renderer replacement/backup path are preflighted. Invalid JSON/TOML, a symlinked
-config, or an unsafe renderer backup conflict aborts the run without touching
-either config. The first changed version is copied to
+config, or an unsafe renderer backup conflict aborts the run without partial
+writes. The first changed version is copied to
 `*.pre-agent-config`; subsequent identical runs perform no writes.
 
 Run the preservation and idempotency test with:

--- a/dotfiles/agent-config.d/codex/60-notifications.toml
+++ b/dotfiles/agent-config.d/codex/60-notifications.toml
@@ -1,0 +1,5 @@
+# Auto-review handles eligible approval requests without human input, so only
+# notify when the agent turn itself finishes and the terminal is not focused.
+[tui]
+notifications = ["agent-turn-complete"]
+notification_condition = "unfocused"

--- a/dotfiles/helpers/install_agent_config.py
+++ b/dotfiles/helpers/install_agent_config.py
@@ -69,12 +69,15 @@ def plan_claude_config(home: Path, fragments_dir: Path) -> tuple[Path, str]:
     return target, json.dumps(merged, indent=2, ensure_ascii=False) + "\n"
 
 
-def load_codex_status_line(fragments_dir: Path) -> list[str]:
+CODEX_TUI_KEYS = {"notification_condition", "notifications", "status_line"}
+
+
+def load_codex_tui_settings(fragments_dir: Path) -> dict[str, Any]:
     fragments = sorted(fragments_dir.glob("*.toml"))
     if not fragments:
         raise SafetyError(f"no Codex TOML fragments found in {fragments_dir}")
 
-    status_line: list[str] | None = None
+    settings: dict[str, Any] = {}
     for fragment_path in fragments:
         try:
             fragment = tomllib.loads(fragment_path.read_text(encoding="utf-8"))
@@ -87,26 +90,41 @@ def load_codex_status_line(fragments_dir: Path) -> list[str]:
             raise SafetyError(
                 f"Codex fragment may only contain the [tui] table: {fragment_path}"
             )
-        if set(fragment["tui"]) != {"status_line"}:
+        if not fragment["tui"]:
             raise SafetyError(
-                "Codex fragment may only set tui.status_line: " f"{fragment_path}"
+                f"Codex fragment must set at least one [tui] key: {fragment_path}"
             )
-        candidate = fragment["tui"]["status_line"]
-        if not isinstance(candidate, list) or not all(
-            isinstance(item, str) and item for item in candidate
-        ):
+        unsupported = set(fragment["tui"]) - CODEX_TUI_KEYS
+        if unsupported:
             raise SafetyError(
-                f"tui.status_line must be an array of non-empty strings: {fragment_path}"
+                "Codex fragment contains unsupported [tui] keys "
+                f"{sorted(unsupported)}: {fragment_path}"
             )
-        status_line = candidate
 
-    assert status_line is not None
-    return status_line
+        for key, candidate in fragment["tui"].items():
+            if key in {"notifications", "status_line"}:
+                if not isinstance(candidate, list) or not all(
+                    isinstance(item, str) and item for item in candidate
+                ):
+                    raise SafetyError(
+                        f"tui.{key} must be an array of non-empty strings: "
+                        f"{fragment_path}"
+                    )
+            elif key == "notification_condition" and candidate not in {
+                "always",
+                "unfocused",
+            }:
+                raise SafetyError(
+                    "tui.notification_condition must be 'always' or 'unfocused': "
+                    f"{fragment_path}"
+                )
+            settings[key] = copy.deepcopy(candidate)
+
+    return settings
 
 
 TABLE_HEADER_RE = re.compile(r"^\s*\[\[?[^]]+\]\]?\s*(?:#.*)?$")
 TUI_HEADER_RE = re.compile(r"^\s*\[tui\]\s*(?:#.*)?$")
-STATUS_LINE_RE = re.compile(r"^(?P<indent>\s*)status_line\s*=")
 
 
 def bracket_delta(line: str) -> int:
@@ -138,20 +156,27 @@ def bracket_delta(line: str) -> int:
     return delta
 
 
-def render_status_line(status_line: list[str], indent: str = "") -> list[str]:
-    lines = [f"{indent}status_line = [\n"]
-    lines.extend(
-        f"{indent}  {json.dumps(item, ensure_ascii=False)},\n"
-        for item in status_line
-    )
-    lines.append(f"{indent}]\n")
-    return lines
+def render_tui_setting(key: str, value: Any, indent: str = "") -> list[str]:
+    if isinstance(value, list):
+        lines = [f"{indent}{key} = [\n"]
+        lines.extend(
+            f"{indent}  {json.dumps(item, ensure_ascii=False)},\n" for item in value
+        )
+        lines.append(f"{indent}]\n")
+        return lines
+    if isinstance(value, str):
+        return [f"{indent}{key} = {json.dumps(value, ensure_ascii=False)}\n"]
+    raise SafetyError(f"cannot render unsupported tui.{key} value")
 
 
-def merge_codex_status_line(original: str, status_line: list[str]) -> str:
+def merge_codex_tui_setting(original: str, key: str, value: Any) -> str:
     lines = original.splitlines(keepends=True)
     tui_index = next(
-        (index for index, line in enumerate(lines) if TUI_HEADER_RE.match(line.rstrip("\n"))),
+        (
+            index
+            for index, line in enumerate(lines)
+            if TUI_HEADER_RE.match(line.rstrip("\r\n"))
+        ),
         None,
     )
 
@@ -161,20 +186,21 @@ def merge_codex_status_line(original: str, status_line: list[str]) -> str:
         if lines and lines[-1].strip():
             lines.append("\n")
         lines.append("[tui]\n")
-        lines.extend(render_status_line(status_line))
+        lines.extend(render_tui_setting(key, value))
         return "".join(lines)
 
     table_end = len(lines)
     for index in range(tui_index + 1, len(lines)):
-        if TABLE_HEADER_RE.match(lines[index].rstrip("\n")):
+        if TABLE_HEADER_RE.match(lines[index].rstrip("\r\n")):
             table_end = index
             break
 
+    setting_re = re.compile(rf"^(?P<indent>\s*){re.escape(key)}\s*=")
     existing_index: int | None = None
     existing_end: int | None = None
     indent = ""
     for index in range(tui_index + 1, table_end):
-        match = STATUS_LINE_RE.match(lines[index])
+        match = setting_re.match(lines[index])
         if not match:
             continue
         existing_index = index
@@ -185,16 +211,25 @@ def merge_codex_status_line(original: str, status_line: list[str]) -> str:
             depth += bracket_delta(lines[existing_end])
             existing_end += 1
         if depth != 0:
-            raise SafetyError("could not find the end of existing tui.status_line")
+            raise SafetyError(f"could not find the end of existing tui.{key}")
         break
 
-    replacement = render_status_line(status_line, indent)
+    replacement = render_tui_setting(key, value, indent)
     if existing_index is not None and existing_end is not None:
         lines[existing_index:existing_end] = replacement
     else:
         insert_at = tui_index + 1
         lines[insert_at:insert_at] = replacement
     return "".join(lines)
+
+
+def merge_codex_tui_settings(original: str, settings: dict[str, Any]) -> str:
+    merged = original
+    # Missing keys are inserted directly after [tui]. Apply in reverse so their
+    # final order still follows the lexical fragment order.
+    for key in reversed(settings):
+        merged = merge_codex_tui_setting(merged, key, settings[key])
+    return merged
 
 
 def plan_codex_config(home: Path, fragments_dir: Path) -> tuple[Path, str]:
@@ -207,16 +242,20 @@ def plan_codex_config(home: Path, fragments_dir: Path) -> tuple[Path, str]:
         except tomllib.TOMLDecodeError as exc:
             raise SafetyError(f"cannot parse Codex config {target}: {exc}") from exc
 
-    status_line = load_codex_status_line(fragments_dir)
-    merged = merge_codex_status_line(original, status_line)
+    settings = load_codex_tui_settings(fragments_dir)
+    merged = merge_codex_tui_settings(original, settings)
     try:
         parsed = tomllib.loads(merged)
     except tomllib.TOMLDecodeError as exc:
         raise SafetyError(
             f"refusing to write invalid merged Codex config {target}: {exc}"
         ) from exc
-    if parsed.get("tui", {}).get("status_line") != status_line:
-        raise SafetyError("merged Codex config did not retain the requested status line")
+    parsed_tui = parsed.get("tui", {})
+    for key, expected in settings.items():
+        if parsed_tui.get(key) != expected:
+            raise SafetyError(
+                f"merged Codex config did not retain the requested tui.{key}"
+            )
     return target, merged
 
 
@@ -315,22 +354,27 @@ def main() -> int:
     claude_target, claude_content = plan_claude_config(
         args.home, fragments_root / "claude"
     )
-    codex_target, codex_content = plan_codex_config(
-        args.home, fragments_root / "codex"
-    )
+    codex_plan = None
+    if shutil.which("codex") is not None:
+        codex_plan = plan_codex_config(args.home, fragments_root / "codex")
     renderer_plan = plan_symlink(
         fragments_root / "claude" / "statusline-command.sh",
         args.home / ".claude" / "statusline-command.sh",
     )
 
     claude_changed = atomic_write(claude_target, claude_content)
-    codex_changed = atomic_write(codex_target, codex_content)
+    codex_changed = atomic_write(*codex_plan) if codex_plan is not None else None
     renderer_changed = apply_symlink(renderer_plan)
 
+    if codex_changed is None:
+        codex_result = "skipped (not installed)"
+    else:
+        codex_result = "updated" if codex_changed else "unchanged"
+
     print(
-        "Agent status config: "
+        "Agent config: "
         f"Claude {'updated' if claude_changed else 'unchanged'}, "
-        f"Codex {'updated' if codex_changed else 'unchanged'}, "
+        f"Codex {codex_result}, "
         f"renderer {'linked' if renderer_changed else 'unchanged'}."
     )
     return 0

--- a/installation/agent-config.sh
+++ b/installation/agent-config.sh
@@ -31,7 +31,7 @@ for candidate in "${python_candidates[@]}"; do
 done
 
 if [ -z "$python_bin" ]; then
-  echo "Skipping optional Claude/Codex status-line config: Python 3.11+ with tomllib is unavailable." >&2
+  echo "Skipping optional Claude/Codex agent config: Python 3.11+ with tomllib is unavailable." >&2
   echo "Re-run installation/agent-config.sh after installing a compatible Python." >&2
   exit 0
 fi

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ echo_green "Installing applications..."
 echo_cyan "About to run '$DOTFILES_CHECKOUT/installation/all.sh'."
 $DOTFILES_CHECKOUT/installation/all.sh
 
-echo_cyan "Configuring optional Claude and Codex status lines..."
+echo_cyan "Configuring optional Claude and Codex agent settings..."
 $DOTFILES_CHECKOUT/installation/agent-config.sh
 
 echo "*******************************************"

--- a/tasks/prd-codex-completion-notifications.md
+++ b/tasks/prd-codex-completion-notifications.md
@@ -1,0 +1,79 @@
+# PRD: Codex Completion Notifications
+
+## Summary
+
+Sync a narrowly owned Codex TUI notification policy through the existing
+`agent-config.d` installer. Machines with Codex installed should receive a ping
+when an agent turn finishes, without treating every Auto-review approval check
+as user-blocking input.
+
+## Codebase Analysis
+
+### Explored
+
+- `installation/agent-config.sh` selects Python 3.11+ and invokes the shared agent-config installer.
+- `dotfiles/helpers/install_agent_config.py` safely merges Claude JSON and the Codex `tui.status_line` setting.
+- `dotfiles/agent-config.d/codex/50-status-line.toml` is the existing Codex fragment.
+- `tests/test-agent-config.sh` covers preservation, preflight safety, backups, and idempotency.
+- `README.md` documents the fragment model and `bash tests/test-agent-config.sh` as the validation command.
+
+### Relevant Patterns
+
+- Agent fragments are applied lexically and own only explicitly supported keys.
+- Codex changes preserve all unrelated TOML bytes and create one recovery copy before the first write.
+- The installer plans and validates changes before modifying either agent config.
+
+### Constraints Discovered
+
+- The standard library has no comment-preserving TOML writer, so Codex uses a narrow text merge.
+- The current Codex fragment validator permits only `tui.status_line`.
+- There is no Makefile; the repository's documented equivalent command surface is `bash tests/test-agent-config.sh`.
+
+### Assumptions Confirmed
+
+- Codex availability means an executable named `codex` is discoverable on `PATH`.
+- The managed notification keys may be replaced; unrelated config and comments must remain untouched.
+- `agent-turn-complete` is the desired event because `approval-requested` is noisy under Auto-review.
+
+## Background
+
+Codex's built-in TUI emits `approval-requested` notifications before automatic
+approval review has decided whether a human is needed. cmux faithfully surfaces
+those messages, creating false "needs input" alerts. Codex supports filtering
+TUI notifications to `agent-turn-complete`, but that preference currently has to
+be maintained manually on each machine.
+
+## Goals
+
+- Sync completion-only, unfocused-window Codex notifications.
+- Preserve existing user configuration outside the explicitly managed keys.
+- Leave Codex config untouched on machines where Codex is not installed.
+- Keep repeated installer runs byte-identical.
+
+## Non-Goals
+
+- Distinguishing post-review human approvals from automatically reviewed approvals.
+- Managing cmux notification policy or sound behavior.
+- Replacing or symlinking the entire `~/.codex/config.toml` file.
+- Adding a new package or TOML-writing dependency.
+
+## Architecture & Approach
+
+- Add `dotfiles/agent-config.d/codex/60-notifications.toml` with the managed notification values.
+- Generalize the Codex fragment loader and text merge to support a small allowlist of `[tui]` keys.
+- Detect Codex with `shutil.which("codex")`; skip Codex planning and writes when it is absent while continuing Claude setup.
+- Extend `tests/test-agent-config.sh` with replacement, creation, absence, preservation, and repeated-run checks.
+- Update `README.md` to document the synced notification policy and conditional behavior.
+
+## Acceptance Criteria
+
+- [ ] AC-1: When `codex` exists on `PATH`, the installer sets `tui.notifications` to `["agent-turn-complete"]` and `tui.notification_condition` to `"unfocused"`.
+- [ ] AC-2: Existing unrelated Codex keys, tables, and comments remain unchanged; only managed TUI values are replaced or inserted.
+- [ ] AC-3: When `codex` is absent, an existing Codex config remains byte-identical and an absent Codex config is not created.
+- [ ] AC-4: A second installer run produces no byte changes to either agent config.
+- [ ] AC-5: Invalid existing agent configuration still fails preflight without partial writes.
+- [ ] AC-6: `bash tests/test-agent-config.sh` passes.
+
+## Open Questions
+
+None.

--- a/tasks/tasks-codex-completion-notifications.md
+++ b/tasks/tasks-codex-completion-notifications.md
@@ -1,0 +1,91 @@
+# Tasks: Codex Completion Notifications
+
+> Generated from [PRD: Codex Completion Notifications](prd-codex-completion-notifications.md)
+
+## Acceptance Criteria Traceability
+
+| AC | Criterion | Tasks |
+|---|---|---|
+| AC-1 | Sync completion-only, unfocused notifications | 1.0 |
+| AC-2 | Preserve unrelated Codex TOML | 1.0 |
+| AC-3 | Skip Codex config when Codex is absent | 1.0 |
+| AC-4 | Repeated runs are byte-identical | 1.0 |
+| AC-5 | Preserve all-or-nothing preflight safety | 1.0 |
+| AC-6 | Existing agent-config suite passes | 1.0 |
+
+## Relevant Files
+
+- `dotfiles/agent-config.d/codex/60-notifications.toml` — new notification fragment.
+- `dotfiles/helpers/install_agent_config.py` — fragment validation, narrow TOML merge, and Codex presence gate.
+- `installation/agent-config.sh` — optional-config deferral wording.
+- `run.sh` — setup progress wording.
+- `tests/test-agent-config.sh` — behavioral regression coverage.
+- `README.md` — synced Codex behavior and conditional-install documentation.
+
+### Notes
+
+- No Makefile exists; use the repository-documented `bash tests/test-agent-config.sh` command.
+- Validation review was required and approved by the human with "go" on 2026-08-02.
+
+## Tasks
+
+- [x] 1.0 Add safe Codex completion-notification sync <- Serves: AC-1, AC-2, AC-3, AC-4, AC-5, AC-6
+  - [x] 1.1 Add failing coverage for managed notification replacement and insertion.
+  - [x] 1.2 Add failing coverage proving Codex absence causes no Codex writes.
+  - [x] 1.3 Add the notification fragment and generalize the allowlisted TUI merge.
+  - [x] 1.4 Gate Codex config planning on the executable being available.
+  - [x] 1.5 Document the behavior and run the full agent-config suite.
+
+  **Pre-implementation validation plan:**
+
+  1. Change existing-config fixtures to contain noisy notification values; run the suite before implementation and require failure because the desired fragment is not yet supported.
+  2. Add absent-Codex fixtures; require failure before implementation because the current installer writes Codex config unconditionally.
+  3. After implementation, run `bash tests/test-agent-config.sh` and require the final PASS marker with exit status 0.
+  4. Inspect the installed TOML semantically with `tomllib` and byte-wise with `cmp`/`grep` assertions already used by the suite.
+  5. Run `python3 -m py_compile dotfiles/helpers/install_agent_config.py` and `bash -n tests/test-agent-config.sh installation/agent-config.sh`.
+  6. Review `git diff --check`, the scoped diff, and repository status before committing.
+
+  **Task 1.0 Preflight:**
+
+  - Validation plan written: yes
+  - Validation plan saved in artifact: yes
+  - Validation review mode recorded in session state: required
+  - Make targets or equivalent command surface identified: yes
+  - Acceptance criteria served by this task listed: yes
+  - Relevant files re-read before modification: yes
+
+  **Validates when:**
+
+  - All six acceptance criteria have direct automated evidence.
+  - The complete agent-config suite exits 0 and reports PASS.
+  - Static syntax and whitespace checks exit 0.
+
+## Validation Results
+
+| # | Check | Result | Evidence |
+|---|---|---|---|
+| 1 | Notification tests fail before implementation | PASS | Initial suite exited 1 at the expected notification assertion. |
+| 2 | Desired notification values replace noisy existing values | PASS | `tomllib` assertions verify `agent-turn-complete` and `unfocused`. |
+| 3 | Missing Codex leaves existing/absent Codex config untouched | PASS | Byte comparison, backup absence, and file-absence assertions pass. |
+| 4 | Unrelated config, comments, and all-or-nothing preflight survive | PASS | Existing preservation, invalid JSON/TOML, symlink, and backup-conflict cases pass. |
+| 5 | Repeated installer run is byte-identical | PASS | Second-run `cmp` checks pass and installer reports both configs unchanged. |
+| 6 | Full test suite | PASS | `bash tests/test-agent-config.sh` exits 0 with the final PASS marker. |
+| 7 | Static checks | PASS | `bash -n ...` and `git diff --check` exit 0. |
+
+### Phase-Gate Audit
+
+**Result:** PASS
+
+**Rules compliance:** Validation was approved and recorded before implementation; tests were written and observed red before the allowlisted merge was generalized.
+
+**Listed done but not actually done:** None.
+
+**Required but not done:** Remote publication remains human-owned under repository policy.
+
+**Done differently than documented:** None.
+
+**Documentation/state updates needed:** Temporary session state removed after completion; PRD and task evidence retained for review.
+
+**Verification performed:** Full behavioral suite, shell syntax checks, and whitespace validation all pass.
+
+**Recommended next action:** Review the local commit, then push the branch and open the prepared draft PR.

--- a/tests/test-agent-config.sh
+++ b/tests/test-agent-config.sh
@@ -7,6 +7,16 @@ installer="$repo_root/installation/agent-config.sh"
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
+python_bin=$(command -v python3)
+codex_bin_dir="$test_root/with-codex"
+mkdir -p "$codex_bin_dir"
+cat >"$codex_bin_dir/codex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$codex_bin_dir/codex"
+export PATH="$codex_bin_dir:$PATH"
+
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -74,7 +84,8 @@ pet = "null-signal"
 status_line = [
   "current-dir",
 ]
-notifications = ["agent-turn-complete"]
+notifications = ["approval-requested"]
+notification_condition = "always"
 
 [projects."/tmp/sentinel"]
 trust_level = "trusted"
@@ -116,6 +127,7 @@ assert config["model"] == "sentinel-model"
 assert config["features"]["hooks"] is True
 assert config["tui"]["pet"] == "null-signal"
 assert config["tui"]["notifications"] == ["agent-turn-complete"]
+assert config["tui"]["notification_condition"] == "unfocused"
 assert config["tui"]["status_line"] == expected
 assert config["projects"]["/tmp/sentinel"]["trust_level"] == "trusted"
 PY
@@ -149,7 +161,43 @@ with open(sys.argv[1], "rb") as handle:
     config = tomllib.load(handle)
 assert config["model"] == "keep-me"
 assert config["tui"]["status_line"][0] == "model"
+assert config["tui"]["notifications"] == ["agent-turn-complete"]
+assert config["tui"]["notification_condition"] == "unfocused"
 PY
+
+# Codex config is left entirely alone when the codex executable is unavailable.
+no_codex_path="$test_root/path-without-codex"
+mkdir -p "$no_codex_path"
+ln -s "$(command -v dirname)" "$no_codex_path/dirname"
+
+no_codex_home="$test_root/no-codex-home"
+mkdir -p "$no_codex_home/.claude" "$no_codex_home/.codex"
+printf '%s\n' '{"sentinel": "claude-is-still-configured"}' \
+  >"$no_codex_home/.claude/settings.json"
+cat >"$no_codex_home/.codex/config.toml" <<'TOML'
+# codex-must-remain-byte-identical
+[tui]
+notifications = ["approval-requested"]
+TOML
+cp "$no_codex_home/.codex/config.toml" "$test_root/no-codex-before.toml"
+HOME="$no_codex_home" PATH="$no_codex_path" PYTHON3_BIN="$python_bin" \
+  /bin/bash "$installer" >/dev/null
+cmp "$test_root/no-codex-before.toml" \
+  "$no_codex_home/.codex/config.toml" || \
+  fail "missing Codex changed an existing Codex config"
+[ ! -e "$no_codex_home/.codex/config.toml.pre-agent-config" ] || \
+  fail "missing Codex created a Codex config backup"
+jq -e '.statusLine.command == "bash \"$HOME/.claude/statusline-command.sh\""' \
+  "$no_codex_home/.claude/settings.json" >/dev/null || \
+  fail "missing Codex prevented Claude configuration"
+
+fresh_no_codex_home="$test_root/fresh-no-codex-home"
+mkdir -p "$fresh_no_codex_home/.claude"
+printf '%s\n' '{}' >"$fresh_no_codex_home/.claude/settings.json"
+HOME="$fresh_no_codex_home" PATH="$no_codex_path" PYTHON3_BIN="$python_bin" \
+  /bin/bash "$installer" >/dev/null
+[ ! -e "$fresh_no_codex_home/.codex/config.toml" ] || \
+  fail "missing Codex created a new Codex config"
 
 # Invalid inputs abort before either agent config is touched.
 invalid_home="$test_root/invalid-home"


### PR DESCRIPTION
## Summary

- sync a completion-only Codex TUI notification policy through the existing `agent-config.d` installer
- preserve unrelated `~/.codex/config.toml` content with an allowlisted, idempotent text merge
- skip Codex config planning and writes when the `codex` executable is unavailable
- extend the agent-config regression suite and document the conditional behavior

## Why

Codex emits `approval-requested` notifications before Auto-review has decided whether human input is actually required. cmux surfaces those events as "Codex needs input," creating repeated false-positive alerts while the reviewer is handling the request automatically.

This change manages the following quieter policy:

```toml
[tui]
notifications = ["agent-turn-complete"]
notification_condition = "unfocused"
```

That retains useful completion pings without notifying for each automatically reviewed approval boundary.

## Safety and compatibility

- Codex settings are applied only when `codex` is discoverable on `PATH`.
- Existing unrelated keys, tables, and comments remain untouched.
- Only `tui.status_line`, `tui.notifications`, and `tui.notification_condition` are accepted from managed Codex fragments.
- Invalid selected configuration still aborts during preflight without partial writes.
- The first changed config receives the existing `.pre-agent-config` recovery copy.
- Repeated runs are byte-identical.

## Validation

- `bash tests/test-agent-config.sh`
- `bash -n tests/test-agent-config.sh installation/agent-config.sh run.sh`
- `git diff --check`

The test suite covers noisy-value replacement, missing `[tui]` insertion, Codex-present and Codex-absent behavior, unrelated-config preservation, invalid configuration, symlink safety, backup conflicts, and second-run idempotency.
